### PR TITLE
[#11] docs : issue template 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,27 @@
+name: Bug 😡
+description: Tell us about any bugs you find
+title: '[Bug]: '
+labels: ['Bug Report 😡']
+body:
+  - type: textarea
+    id: bug
+    attributes:
+      label: 'Bug report ✍️'
+      description: Please write a description of the bug or error
+    validations:
+      required: true
+  - type: textarea
+    id: modification
+    attributes:
+      label: 'How to fix? 🤔'
+      description: Please tell me how to fix it
+    validations:
+      required: false
+
+  - type: textarea
+    id: expectation
+    attributes:
+      label: 'Expection 👀'
+      description: Please write a description of what you expect to happen
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/help.yml
+++ b/.github/ISSUE_TEMPLATE/help.yml
@@ -1,0 +1,20 @@
+name: Help 🤷‍♀️🤷🤷‍♂️
+description: Submit when asking for help
+title: '[Help]: '
+labels: ['Help 🤷‍♀️🤷🤷‍♂️']
+body:
+  - type: textarea
+    id: work
+    attributes:
+      label: 'Progress 📑'
+      description: What are you currently working on??
+    validations:
+      required: true
+
+  - type: textarea
+    id: help
+    attributes:
+      label: 'Help 🤷‍♀️🤷🤷‍♂️'
+      description: What do you need help with?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,20 @@
+name: Question 🙋🙋‍♀️🙋‍♂️
+description: Tell us about your questions or improvements
+title: '[Question]: '
+labels: ['Question 🙋🙋‍♀️🙋‍♂️']
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: 'Question 🙋🙋‍♀️🙋‍♂️'
+      description: Please write a description of your question or what do you want to improvement
+    validations:
+      required: true
+
+  - type: textarea
+    id: expectation
+    attributes:
+      label: 'Expection 👀'
+      description: Please write a description of what you expect to happen.
+    validations:
+      required: false


### PR DESCRIPTION
- bug report issue
- help issue
- question issue

# ISSUE <#11> {issue template 추가}

# MOTIVATIONS 🧐

why did you do this?
범수형이 bug 고치는 모습을 옆에서 봤는데, 따로 이슈 탭이 없어서 버그나, 도움이 필요한 것 그리고 의견을 물어보거나 할 때 이슈에 정리해서 적어놓으면 다른 사람이 보고 도와줄 수 있을 것이라고 생각해서 추가하였음.

<hr>

# KEY CHANGES 🙋‍♀️

What changed?
.github/ISSUE_TEMPLATE 에 bug, help, question issue template 생성

<hr>

# TO REVIEWERS 🗣️

Tell the reviewer what to look for!
이후에 이슈탭에서 기능 추가를 할 때 Feature을 쓰듯이, 버그가 발생했거나 문제가 발생하면 적어놓고 같이 해결해나가면 될 것 같음! 도움이 필요할 때도 어떤 것을 하다가 문제가 생겼는지 적어놓으면 나중에 회의할 때 같이 해결해도 좋고, 문제가 발생했는데 어떻게 해결해야할 지 모르겠다 같은 부분들 적어놓으면 좋을 것 같음!

<hr>

# TEST 📑

Please tell me how to test it!
